### PR TITLE
Custom edittexts can be a PatternedEdittext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ android:
     - tools
     - build-tools-23.0.3
     - android-23
+    - extra-android-support
+    - extra-android-m2repository
+    - extra-google-m2repository
 
 script:
     - ./gradlew build
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: android
 
 android:
   components:
-    - build-tools-23.1.1
+    - tools
+    - build-tools-23.0.3
     - android-23
 
 script:
-    ./gradlew build
+    - ./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: android
 
 android:
   components:
-    - build-tools-19.1.0
-    - android-19
+    - build-tools-23.1.1
+    - android-23
 
 script:
 	./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ android:
     - build-tools-23.0.3
     - android-23
     - extra-android-support
-    - extra-android-m2repository
-    - extra-google-m2repository
+
 
 script:
     - ./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
     - build-tools-23.0.3
     - android-23
     - extra-android-support
-
+    - extra-android-m2repository
 
 script:
     - ./gradlew build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ android:
     - android-23
 
 script:
-	./gradlew build
+    ./gradlew build

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'org.robolectric:robolectric-gradle-plugin:0.14.0'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip

--- a/gradlew
+++ b/gradlew
@@ -6,11 +6,29 @@
 ##
 ##############################################################################
 
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
+# Attempt to set APP_HOME
+# Resolve links: $0 may be a link
+PRG="$0"
+# Need this for relative symlinks.
+while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+        PRG="$link"
+    else
+        PRG=`dirname "$PRG"`"/$link"
+    fi
+done
+SAVED="`pwd`"
+cd "`dirname \"$PRG\"`/" >/dev/null
+APP_HOME="`pwd -P`"
+cd "$SAVED" >/dev/null
 
 APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
+
+# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+DEFAULT_JVM_OPTS=""
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"
@@ -30,6 +48,7 @@ die ( ) {
 cygwin=false
 msys=false
 darwin=false
+nonstop=false
 case "`uname`" in
   CYGWIN* )
     cygwin=true
@@ -40,30 +59,10 @@ case "`uname`" in
   MINGW* )
     msys=true
     ;;
+  NONSTOP* )
+    nonstop=true
+    ;;
 esac
-
-# For Cygwin, ensure paths are in UNIX format before anything is touched.
-if $cygwin ; then
-    [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
-fi
-
-# Attempt to set APP_HOME
-# Resolve links: $0 may be a link
-PRG="$0"
-# Need this for relative symlinks.
-while [ -h "$PRG" ] ; do
-    ls=`ls -ld "$PRG"`
-    link=`expr "$ls" : '.*-> \(.*\)$'`
-    if expr "$link" : '/.*' > /dev/null; then
-        PRG="$link"
-    else
-        PRG=`dirname "$PRG"`"/$link"
-    fi
-done
-SAVED="`pwd`"
-cd "`dirname \"$PRG\"`/" >&-
-APP_HOME="`pwd -P`"
-cd "$SAVED" >&-
 
 CLASSPATH=$APP_HOME/gradle/wrapper/gradle-wrapper.jar
 
@@ -90,7 +89,7 @@ location of your Java installation."
 fi
 
 # Increase the maximum file descriptors if we can.
-if [ "$cygwin" = "false" -a "$darwin" = "false" ] ; then
+if [ "$cygwin" = "false" -a "$darwin" = "false" -a "$nonstop" = "false" ] ; then
     MAX_FD_LIMIT=`ulimit -H -n`
     if [ $? -eq 0 ] ; then
         if [ "$MAX_FD" = "maximum" -o "$MAX_FD" = "max" ] ; then
@@ -114,6 +113,7 @@ fi
 if $cygwin ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
+    JAVACMD=`cygpath --unix "$JAVACMD"`
 
     # We build the pattern for arguments to be converted via cygpath
     ROOTDIRSRAW=`find -L / -maxdepth 1 -mindepth 1 -type d 2>/dev/null`

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -8,13 +8,13 @@
 @rem Set local scope for the variables with windows NT shell
 if "%OS%"=="Windows_NT" setlocal
 
-@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
-
 set DIRNAME=%~dp0
 if "%DIRNAME%" == "" set DIRNAME=.
 set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome
@@ -46,7 +46,7 @@ echo location of your Java installation.
 goto fail
 
 :init
-@rem Get command-line arguments, handling Windowz variants
+@rem Get command-line arguments, handling Windows variants
 
 if not "%OS%" == "Windows_NT" goto win9xME_args
 if "%@eval[2+2]" == "4" goto 4NT_args

--- a/patterned-edit-text-sample/build.gradle
+++ b/patterned-edit-text-sample/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 apply plugin: 'com.android.application'

--- a/patterned-edit-text-sample/build.gradle
+++ b/patterned-edit-text-sample/build.gradle
@@ -13,12 +13,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 23
     buildToolsVersion "19.1.0"
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -32,6 +32,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:19.+'
+    compile 'com.android.support:appcompat-v7:23.1.1'
     compile project(':patterned-edit-text')
 }

--- a/patterned-edit-text-sample/build.gradle
+++ b/patterned-edit-text-sample/build.gradle
@@ -14,7 +14,7 @@ repositories {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "19.1.0"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 8
@@ -32,6 +32,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:23.3.0'
     compile project(':patterned-edit-text')
 }

--- a/patterned-edit-text/build.gradle
+++ b/patterned-edit-text/build.gradle
@@ -3,12 +3,12 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.github.dcendents:android-maven-plugin:1.2'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'robolectric'
+//apply plugin: 'idea'
 
 repositories {
     mavenCentral()
@@ -16,7 +16,7 @@ repositories {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '19.1.0'
+    buildToolsVersion '23.0.3'
 
     defaultConfig {
         minSdkVersion 8
@@ -40,38 +40,17 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile 'org.hamcrest:hamcrest-core:1.1'
-    androidTestCompile 'org.hamcrest:hamcrest-library:1.1'
-    androidTestCompile('junit:junit:4.11') {
-        exclude module: 'hamcrest-core'
-    }
-    androidTestCompile('org.robolectric:robolectric:2.4') {
-        exclude module: 'classworlds'
-        exclude module: 'commons-logging'
-        exclude module: 'httpclient'
-        exclude module: 'maven-artifact'
-        exclude module: 'maven-artifact-manager'
-        exclude module: 'maven-error-diagnostics'
-        exclude module: 'maven-model'
-        exclude module: 'maven-project'
-        exclude module: 'maven-settings'
-        exclude module: 'plexus-container-default'
-        exclude module: 'plexus-interpolation'
-        exclude module: 'plexus-utils'
-        exclude module: 'wagon-file'
-        exclude module: 'wagon-http-lightweight'
-        exclude module: 'wagon-provider-api'
-    }
-    androidTestCompile 'org.mockito:mockito-core:1.9.5'
-}
+    androidTestCompile 'org.hamcrest:hamcrest-core:1.3'
+    androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
 
-apply plugin: 'idea'
-idea {
-    module {
-        testOutputDir = file('build/test-classes/debug')
-    }
-}
+    androidTestCompile 'com.android.support.test:runner:0.4.1'
+    androidTestCompile 'com.android.support.test:rules:0.4.1'
+    androidTestCompile "com.android.support:support-annotations:23.3.0"
 
-apply plugin: 'android-maven'
+    testCompile 'junit:junit:4.12'
+    testCompile('org.robolectric:robolectric:3.0')
+
+}
+apply plugin: 'com.github.dcendents.android-maven'
 version = "1.0"
 group = "com.faradaj"

--- a/patterned-edit-text/build.gradle
+++ b/patterned-edit-text/build.gradle
@@ -14,6 +14,13 @@ repositories {
     mavenCentral()
 }
 
+ext {
+    travisBuild = System.getenv("TRAVIS") == "true"
+    // allows for -Dpre-dex=false to be set
+    preDexEnabled = "true".equals(System.getProperty("pre-dex", "true"))
+}
+
+
 android {
     compileSdkVersion 23
     buildToolsVersion '23.0.3'
@@ -36,7 +43,14 @@ android {
             setRoot('src/test')
         }
     }
+    dexOptions {
+        // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
+        preDexLibraries = preDexEnabled && !travisBuild
+    }
+
 }
+
+
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
@@ -50,6 +64,10 @@ dependencies {
     testCompile('org.robolectric:robolectric:3.0')
 
 }
+
+
+
 apply plugin: 'com.github.dcendents.android-maven'
 version = "1.0"
 group = "com.faradaj"
+

--- a/patterned-edit-text/build.gradle
+++ b/patterned-edit-text/build.gradle
@@ -15,12 +15,12 @@ repositories {
 }
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 23
     buildToolsVersion '19.1.0'
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 19
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }

--- a/patterned-edit-text/build.gradle
+++ b/patterned-edit-text/build.gradle
@@ -45,7 +45,6 @@ dependencies {
 
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.android.support.test:rules:0.4.1'
-    androidTestCompile "com.android.support:support-annotations:23.3.0"
 
     testCompile 'junit:junit:4.12'
     testCompile('org.robolectric:robolectric:3.0')

--- a/patterned-edit-text/build.gradle
+++ b/patterned-edit-text/build.gradle
@@ -37,6 +37,9 @@ android {
             proguardFiles 'proguard-rules.txt'
         }
     }
+    lintOptions {
+        abortOnError false
+    }
 
     sourceSets {
         androidTest {

--- a/patterned-edit-text/src/main/java/com/faradaj/patternededittext/PatternedEditText.java
+++ b/patterned-edit-text/src/main/java/com/faradaj/patternededittext/PatternedEditText.java
@@ -1,176 +1,74 @@
 package com.faradaj.patternededittext;
 
 import android.content.Context;
-import android.content.res.TypedArray;
 import android.os.Parcelable;
-import android.text.Editable;
-import android.text.InputFilter;
-import android.text.TextWatcher;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.widget.EditText;
-import com.faradaj.patternededittext.utils.PatternUtils;
 
 public class PatternedEditText extends EditText {
 
-    private String mSpecialChar;
-    private String mPattern;
-
-    private String mRawText = "";
+    private PatternedViewHelper patternedViewHelper;
 
     public PatternedEditText(Context context) {
         super(context);
+        init(null);
     }
 
     public PatternedEditText(Context context, AttributeSet attrs) {
         super(context, attrs);
+        init(attrs);
 
-        TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.PatternedEditText);
-        mPattern = a.getString(R.styleable.PatternedEditText_pattern);
-        mSpecialChar = a.getString(R.styleable.PatternedEditText_specialChar);
-        if (mSpecialChar == null) {
-            mSpecialChar = "#";
-        }
-        boolean showHint = a.getBoolean(R.styleable.PatternedEditText_showPatternAsHint, false);
-        a.recycle();
-
-        setFilters(new InputFilter[]{new InputFilter.LengthFilter(mPattern.length())});
-
-        if (showHint) {
-            setHint(mPattern);
-        }
-
-        final TextWatcher textWatcher = new TextWatcher() {
-            private boolean mForcing = false;
-            private StringBuilder sb;
-
-            private boolean isDeleting = false;
-
-            private int differenceCount = 0;
-            public int toBeSetCursorPosition = 0;
-            public int mBeforeTextLength = 0;
-
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-                mBeforeTextLength = s.length();
-                if (!mForcing) {
-                    sb = new StringBuilder();
-                    differenceCount = PatternUtils.getDifferenceCount(s.toString().substring(0, getSelectionStart()), mPattern, mSpecialChar.charAt(0));
-                    sb.append(mRawText);
-                    if (after == 0) {
-                        isDeleting = true;
-                        try {
-                            sb.delete(getSelectionEnd() - count - differenceCount, getSelectionEnd() - differenceCount);
-                        } catch (IndexOutOfBoundsException e) {
-                            //Do nothing. User tried to delete unremovable char(s) of pattern.
-                        }
-                    } else {
-                        isDeleting = false;
-                    }
-                }
-            }
-
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-                if (!mForcing) {
-                    if (!isDeleting) {
-                        try {
-                            int from = getSelectionEnd() - count - differenceCount;
-                            if (from < 0) {
-                                from = 0;
-                            }
-                            sb.insert(from, s.subSequence(start, start + count));
-                        } catch (StringIndexOutOfBoundsException e) {
-                            Log.e("PatternedEditText: ", e.toString());
-                            //getSelectionEnd() returns 0 after screen rotation.
-                            //Added to handle filling EditText after rotation.
-                            //onRestoreInstanceState() is responsible for setting text.
-                        }
-                    }
-                }
-            }
-
-            @Override
-            public void afterTextChanged(Editable s) {
-                if (!mForcing) {
-                    mForcing = true;
-                    mRawText = sb.toString();
-                    String convertedText;
-                    if (PatternUtils.isTextAppliesPattern(mRawText, mPattern, mSpecialChar.charAt(0))) {
-                        convertedText = mRawText;
-                        mRawText = PatternUtils.convertPatternedTextToText(mRawText, mPattern, mSpecialChar.charAt(0));
-                    } else {
-                        convertedText = PatternUtils.convertTextToPatternedText(mRawText, mPattern, mSpecialChar.charAt(0));
-                    }
-                    toBeSetCursorPosition = getSelectionStart() + convertedText.length() - s.length();
-                    if (mBeforeTextLength == 0) {
-                        toBeSetCursorPosition = convertedText.length();
-                    }
-                    s.clear();
-                    s.append(convertedText);
-                    try {
-                        if (isDeleting) {
-                            if (toBeSetCursorPosition < convertedText.length()) {
-                                ++toBeSetCursorPosition;
-                            }
-                        } else if (toBeSetCursorPosition != convertedText.length()) {
-                            --toBeSetCursorPosition;
-                        }
-                        setSelection(toBeSetCursorPosition);
-                    } catch (IndexOutOfBoundsException e) {
-                        Log.e("PatternedEditText: ", e.toString());
-                    }
-                    mForcing = false;
-                }
-            }
-        };
-
-        addTextChangedListener(textWatcher);
     }
 
     public PatternedEditText(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        init(attrs);
+    }
+
+    private void init(AttributeSet attrs){
+        patternedViewHelper=new PatternedViewHelper(this);
+        patternedViewHelper.resolveAttributes(attrs);
     }
 
     @Override
     public void setText(CharSequence text, BufferType type) {
-        this.mRawText = "";
+        if(patternedViewHelper!=null) {
+            patternedViewHelper.setText();
+        }
         super.setText(text, type);
     }
+
 
     @Override
     public Parcelable onSaveInstanceState() {
         Parcelable superState = super.onSaveInstanceState();
-
-        return new PetSavedState(superState, mRawText);
+        return patternedViewHelper.onSaveInstanceState(superState);
     }
 
     @Override
     public void onRestoreInstanceState(Parcelable state) {
-        PetSavedState savedState = (PetSavedState) state;
+        BaseSavedState savedState = (BaseSavedState) state;
         super.onRestoreInstanceState(savedState.getSuperState());
-
-        mRawText = savedState.getRealText();
-        setText(mRawText);
+        patternedViewHelper.onRestoreInstanceState(state);
     }
 
     public String getRawText() {
-        return mRawText;
+        return patternedViewHelper.getRawText();
     }
 
     public String getSpecialChar() {
-        return mSpecialChar;
+        return patternedViewHelper.getSpecialChar();
     }
 
     public void setSpecialChar(String specialChar) {
-        this.mSpecialChar = specialChar;
+        patternedViewHelper.setSpecialChar(specialChar);
     }
 
     public String getPattern() {
-        return mPattern;
+        return patternedViewHelper.getPattern();
     }
 
     public void setPattern(String pattern) {
-        this.mPattern = pattern;
+        patternedViewHelper.setPattern(pattern);
     }
 }

--- a/patterned-edit-text/src/main/java/com/faradaj/patternededittext/PatternedViewHelper.java
+++ b/patterned-edit-text/src/main/java/com/faradaj/patternededittext/PatternedViewHelper.java
@@ -1,0 +1,172 @@
+package com.faradaj.patternededittext;
+
+import android.content.res.TypedArray;
+import android.os.Parcelable;
+import android.text.Editable;
+import android.text.InputFilter;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.widget.EditText;
+
+import com.faradaj.patternededittext.utils.PatternUtils;
+
+/**
+ * Created by erdemmac on 31/01/16.
+ * <p/>
+ * <p/>
+ * Helper class to manage all patterned edittext features.
+ * Any custom class can use this helper to create default behaviour of #PatternedEdittext
+ */
+public class PatternedViewHelper {
+
+    private String mSpecialChar;
+    private String mPattern;
+
+    private String mRawText = "";
+
+    private EditText editText;
+
+    public PatternedViewHelper(EditText et) {
+        this.editText = et;
+    }
+
+    public void resolveAttributes( AttributeSet attrs) {
+        if(attrs==null)return;
+        TypedArray a = editText.getContext().obtainStyledAttributes(attrs, R.styleable.PatternedEditText);
+        mPattern = a.getString(R.styleable.PatternedEditText_pattern);
+        mSpecialChar = a.getString(R.styleable.PatternedEditText_specialChar);
+        if (mSpecialChar == null) {
+            mSpecialChar = "#";
+        }
+        boolean showHint = a.getBoolean(R.styleable.PatternedEditText_showPatternAsHint, false);
+        a.recycle();
+
+        editText.setFilters(new InputFilter[]{new InputFilter.LengthFilter(mPattern.length())});
+
+        if (showHint) {
+            editText.setHint(mPattern);
+        }
+
+        final TextWatcher textWatcher = new TextWatcher() {
+            private boolean mForcing = false;
+            private StringBuilder sb;
+
+            private boolean isDeleting = false;
+
+            private int differenceCount = 0;
+            public int toBeSetCursorPosition = 0;
+            public int mBeforeTextLength = 0;
+
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                mBeforeTextLength = s.length();
+                if (!mForcing) {
+                    sb = new StringBuilder();
+                    differenceCount = PatternUtils.getDifferenceCount(s.toString().substring(0, editText.getSelectionStart()), mPattern, mSpecialChar.charAt(0));
+                    sb.append(mRawText);
+                    if (after == 0) {
+                        isDeleting = true;
+                        try {
+                            sb.delete(editText.getSelectionEnd() - count - differenceCount, editText.getSelectionEnd() - differenceCount);
+                        } catch (IndexOutOfBoundsException e) {
+                            //Do nothing. User tried to delete unremovable char(s) of pattern.
+                        }
+                    } else {
+                        isDeleting = false;
+                    }
+                }
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                if (!mForcing) {
+                    if (!isDeleting) {
+                        try {
+                            int from = editText.getSelectionEnd() - count - differenceCount;
+                            if (from < 0) {
+                                from = 0;
+                            }
+                            sb.insert(from, s.subSequence(start, start + count));
+                        } catch (StringIndexOutOfBoundsException e) {
+                            Log.e("PatternedEditText: ", e.toString());
+                            //getSelectionEnd() returns 0 after screen rotation.
+                            //Added to handle filling EditText after rotation.
+                            //onRestoreInstanceState() is responsible for setting text.
+                        }
+                    }
+                }
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                if (!mForcing) {
+                    mForcing = true;
+                    mRawText = sb.toString();
+                    String convertedText;
+                    if (PatternUtils.isTextAppliesPattern(mRawText, mPattern, mSpecialChar.charAt(0))) {
+                        convertedText = mRawText;
+                        mRawText = PatternUtils.convertPatternedTextToText(mRawText, mPattern, mSpecialChar.charAt(0));
+                    } else {
+                        convertedText = PatternUtils.convertTextToPatternedText(mRawText, mPattern, mSpecialChar.charAt(0));
+                    }
+                    toBeSetCursorPosition = editText.getSelectionStart() + convertedText.length() - s.length();
+                    if (mBeforeTextLength == 0) {
+                        toBeSetCursorPosition = convertedText.length();
+                    }
+                    s.clear();
+                    s.append(convertedText);
+                    try {
+                        if (isDeleting) {
+                            if (toBeSetCursorPosition < convertedText.length()) {
+                                ++toBeSetCursorPosition;
+                            }
+                        } else if (toBeSetCursorPosition != convertedText.length()) {
+                            --toBeSetCursorPosition;
+                        }
+                        editText.setSelection(toBeSetCursorPosition);
+                    } catch (IndexOutOfBoundsException e) {
+                        Log.e("PatternedEditText: ", e.toString());
+                    }
+                    mForcing = false;
+                }
+            }
+        };
+        editText.addTextChangedListener(textWatcher);
+    }
+
+    public Parcelable onSaveInstanceState(Parcelable superState) {
+        return new PetSavedState(superState, mRawText);
+    }
+
+    public void onRestoreInstanceState(Parcelable state) {
+        PetSavedState savedState = (PetSavedState) state;
+        mRawText = savedState.getRealText();
+        editText.setText(mRawText);
+    }
+
+    public void setText() {
+        this.mRawText = "";
+    }
+
+    public String getRawText() {
+        return mRawText;
+    }
+
+    public String getSpecialChar() {
+        return mSpecialChar;
+    }
+
+    public void setSpecialChar(String specialChar) {
+        this.mSpecialChar = specialChar;
+    }
+
+    public String getPattern() {
+        return mPattern;
+    }
+
+    public void setPattern(String pattern) {
+        this.mPattern = pattern;
+    }
+
+}

--- a/patterned-edit-text/src/test/java/com/faradaj/patternededittext/utils/PatternUtilsTest.java
+++ b/patterned-edit-text/src/test/java/com/faradaj/patternededittext/utils/PatternUtilsTest.java
@@ -1,17 +1,13 @@
 package com.faradaj.patternededittext.utils;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Config(emulateSdk = 18)
-@RunWith(RobolectricTestRunner.class)
+
 public class PatternUtilsTest {
 
     private String mSpecialChar = "#";
@@ -24,27 +20,27 @@ public class PatternUtilsTest {
 
         String givenString;
 
-        mPattern="#-#";
+        mPattern = "#-#";
         givenString = "a";
         assertEquals("a", PatternUtils.convertTextToPatternedText(givenString, mPattern, specialChar));
 
-        mPattern="#-#";
+        mPattern = "#-#";
         givenString = "ab";
         assertEquals("a-b", PatternUtils.convertTextToPatternedText(givenString, mPattern, specialChar));
 
-        mPattern="#-#)#";
+        mPattern = "#-#)#";
         givenString = "abc";
         assertEquals("a-b)c", PatternUtils.convertTextToPatternedText(givenString, mPattern, specialChar));
 
-        mPattern="#-#)#)";
+        mPattern = "#-#)#)";
         givenString = "abc";
         assertEquals("a-b)c)", PatternUtils.convertTextToPatternedText(givenString, mPattern, specialChar));
 
-        mPattern="#### #### #### ####";
+        mPattern = "#### #### #### ####";
         givenString = "1234123412341234";
         assertEquals("1234 1234 1234 1234", PatternUtils.convertTextToPatternedText(givenString, mPattern, specialChar));
 
-        mPattern="(###)-(### ## ##)";
+        mPattern = "(###)-(### ## ##)";
         givenString = "5321234567";
         assertEquals("(532)-(123 45 67)", PatternUtils.convertTextToPatternedText(givenString, mPattern, specialChar));
     }
@@ -83,7 +79,7 @@ public class PatternUtilsTest {
         assertTrue(!PatternUtils.isTextAppliesPattern(patternedText, mPattern, specialChar));
 
         patternedText = "(532)-(123 45 67)";
-        mPattern="(###)-(### ## ##)";
+        mPattern = "(###)-(### ## ##)";
         assertTrue(PatternUtils.isTextAppliesPattern(patternedText, mPattern, specialChar));
     }
 
@@ -93,33 +89,33 @@ public class PatternUtilsTest {
 
         String givenString;
 
-        mPattern="#-#";
+        mPattern = "#-#";
         givenString = "a-";
         assertEquals("a", PatternUtils.convertPatternedTextToText(givenString, mPattern, specialChar));
 
-        mPattern="#-#";
+        mPattern = "#-#";
         givenString = "a-b";
         assertEquals("ab", PatternUtils.convertPatternedTextToText(givenString, mPattern, specialChar));
 
-        mPattern="#-#)#";
+        mPattern = "#-#)#";
         givenString = "a-b)c";
         assertEquals("abc", PatternUtils.convertPatternedTextToText(givenString, mPattern, specialChar));
 
-        mPattern="#-#)#)";
+        mPattern = "#-#)#)";
         givenString = "a-b)c)";
         assertEquals("abc", PatternUtils.convertPatternedTextToText(givenString, mPattern, specialChar));
 
-        mPattern="#### #### #### ####";
+        mPattern = "#### #### #### ####";
         givenString = "1234 1234 1234 1234";
         assertEquals("1234123412341234", PatternUtils.convertPatternedTextToText(givenString, mPattern, specialChar));
 
-        mPattern="(###)-(### ## ##)";
+        mPattern = "(###)-(### ## ##)";
         givenString = "(532)-(123 45 67)";
         assertEquals("5321234567", PatternUtils.convertPatternedTextToText(givenString, mPattern, specialChar));
     }
 
     @Test
-     public void testBasicPattern() {
+    public void testBasicPattern() {
         mPattern = "######";
 
         mSpans = PatternUtils.generateSpansFromPattern(mSpecialChar, mPattern);


### PR DESCRIPTION
Any custom edittext can be converted into PatternedEditext using PatternedViewHelper.
For my case AppCompatEdittext with Pattern properties was missing.

``` java
public class PatternedCompatEdittext extends AppCompatEditText {

    private PatternedViewHelper patternedViewHelper;

    public PatternedCompatEdittext(Context context) {
        super(context);
        init(null);
    }

    public PatternedCompatEdittext(Context context, AttributeSet attrs) {
        super(context, attrs);
        init(attrs);

    }

    public PatternedCompatEdittext(Context context, AttributeSet attrs, int defStyle) {
        super(context, attrs, defStyle);
        init(attrs);
    }

    private void init(AttributeSet attrs) {
        patternedViewHelper = new PatternedViewHelper(this);
        patternedViewHelper.resolveAttributes(attrs);
    }

    @Override
    public void setText(CharSequence text, BufferType type) {
        if (patternedViewHelper != null) {
            patternedViewHelper.setText();
        }
        super.setText(text, type);
    }


    @Override
    public Parcelable onSaveInstanceState() {
        Parcelable superState = super.onSaveInstanceState();
        return patternedViewHelper.onSaveInstanceState(superState);
    }

    @Override
    public void onRestoreInstanceState(Parcelable state) {
        BaseSavedState savedState = (BaseSavedState) state;
        super.onRestoreInstanceState(savedState.getSuperState());
        patternedViewHelper.onRestoreInstanceState(state);
    }

```
